### PR TITLE
Auf Fehlimplementierung hingewiesen.

### DIFF
--- a/PHPScripts/setuser.php
+++ b/PHPScripts/setuser.php
@@ -50,7 +50,7 @@ switch ($method){
 */
 function validate($kurz, $pwd){
    $con = mysqli_connect(HOST,USER,PASS,DB);
-
+   // In so vielen Schichten falsch. Passwörter müssen gehasht sein. So nicht.
     $sql = "select * from schmidt_user where token='".$kurz."' and pwd='".$pwd."'";
     //$sql = "select * from schmidt_user";
     $res = mysqli_query($con,$sql);


### PR DESCRIPTION
In der Funktion "validate" wird das Passwort per SQL abfrage geholt. An sich nicht schlimm. Was nicht geht, ist der Umstand, dass das Passwort im Plain-Text abgelegt ist.